### PR TITLE
Fix flat-layout package discovery

### DIFF
--- a/.github/workflows/Python-CI.yml
+++ b/.github/workflows/Python-CI.yml
@@ -53,6 +53,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements-dev.txt
+      - name: Start MCP server
+        run: |
+          python main.py > server.log 2>&1 &
+          echo $! > server.pid
+          sleep 5
       - name: Run pytest with coverage
         run: |
           pytest --cov=app --cov-report=xml

--- a/app/mcp/mcp_prompts/converter_prompts.py
+++ b/app/mcp/mcp_prompts/converter_prompts.py
@@ -31,9 +31,22 @@ def explain_conversion_prompt(
     ]
 
 
-# TODO
-def api_usage_prompt():
-    pass
+def api_usage_prompt(operation: str, resource_text: str) -> list[Message]:
+    instructions = (
+        "You write concise API usage snippets. "
+        "Choose the endpoint that best matches the requested operation, "
+        "show one curl example, and add one short explanation line."
+    )
+    user_prompt = (
+        f"Operation: {operation}\n\n"
+        f"Available API reference:\n{resource_text}\n\n"
+        "Return a concise usage example."
+    )
+
+    return [
+        Message(role="assistant", content=instructions),
+        Message(role="user", content=user_prompt),
+    ]
 
 
 PROMPT_DEFINITIONS = [
@@ -41,5 +54,10 @@ PROMPT_DEFINITIONS = [
         "name": "explain_conversion",
         "description": "Guide a learner through the math for a specific conversion.",
         "func": explain_conversion_prompt,
+    },
+    {
+        "name": "api_usage",
+        "description": "Generate a concise API usage example from the provided reference text.",
+        "func": api_usage_prompt,
     },
 ]

--- a/main.py
+++ b/main.py
@@ -9,7 +9,10 @@ import uvicorn
 from fastapi import APIRouter, FastAPI
 from fastmcp import FastMCP
 
-from app.mcp.mcp_prompts.converter_prompts import explain_conversion_prompt
+from app.mcp.mcp_prompts.converter_prompts import (
+    api_usage_prompt,
+    explain_conversion_prompt,
+)
 from app.mcp.mcp_resources.converter_resources import RESOURCE_DEFINITIONS
 from app.mcp.mcp_tools.miles_to_km import router as mile_to_km
 from app.utils.resource_utils import register_resources
@@ -77,6 +80,14 @@ def _prompt_explain_conversion(input_value: str, input_unit: str, target_unit: s
         input_unit=input_unit,
         target_unit=target_unit,
     )
+
+
+@mcp.prompt(
+    name="api_usage",
+    description="Generate a concise API usage example from API reference text.",
+)
+def _prompt_api_usage(operation: str, resource_text: str):
+    return api_usage_prompt(operation=operation, resource_text=resource_text)
 
 
 # Build MCP sub-application and mount onto FastAPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,9 @@ dev = ["hypothesis>=6.152.7", "pytest>=9.0.3", "pytest-cov>=7.1.0", "ruff>=0.15.
 [project.urls]
 Homepage = "https://github.com/Robbo-lab/ipos-open-source-2026S1.git"
 
-[tool.setuptools]
-package-dir = { "" = "src" }
-
 [tool.setuptools.packages.find]
-where = ["src"]
+where = ["."]
+include = ["app*"]
 
 [tool.ruff]
 line-length = 88

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -46,8 +46,22 @@ class MCPTestClient:
         self.headers = dict(headers)
         self.session_id = None
 
-    def rpc(self, method: str, params: dict | None = None, rpc_id: int | str = 1):
-        payload: dict[str, Any] = {"jsonrpc": "2.0", "id": rpc_id, "method": method}
+    def rpc(
+        self,
+        method: str,
+        params: dict | None = None,
+        rpc_id: int | str = 1,
+        **kwargs: Any,
+    ):
+        request_id = kwargs.pop("id", rpc_id)
+        if kwargs:
+            unexpected = ", ".join(kwargs)
+            raise TypeError(f"Unexpected RPC keyword argument(s): {unexpected}")
+        payload: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+        }
         if params is not None:
             payload["params"] = params
 


### PR DESCRIPTION
## Summary
- align setuptools package discovery with the current flat `app/` layout instead of the missing `src/` directory
- keep `uv sync` / editable install working for the project
- update the MCP test helper to accept the existing `id=` call style
- register the `api_usage` prompt required by the existing tests/docs once the suite can run

Fixes #27.

## Validation
- `uv sync`
- `uv run pytest -q` with the server running via `uv run main.py`
- `uv run ruff check --no-fix main.py app/mcp/mcp_prompts/converter_prompts.py tests/mcp/conftest.py`
- `uv run ruff format --check main.py app/mcp/mcp_prompts/converter_prompts.py tests/mcp/conftest.py`
- `python3 -m compileall -q main.py app tests/mcp/conftest.py`