### PR TITLE
[Refactor]: add a shared response helper for HTTP and MCP outputs

### DIFF
--- a/app/mcp/mcp_resources/converter_resources.py
+++ b/app/mcp/mcp_resources/converter_resources.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.utils.response_helpers import build_success_response
+
 
 def unit_reference() -> dict[str, Any]:
     """
@@ -12,21 +14,23 @@ def unit_reference() -> dict[str, Any]:
     Returns:
         Dictionary describing conversions, formulas, and examples.
     """
-    return {
-        "id": "unit-converter-cheatsheet",
-        "title": "Unit Converter Cheatsheet",
-        "supported": {
-            "distance": {
-                "miles_to_kilometers": {
-                    "formula": "mi ÷ 0.621371",
-                    "example": {"input": 3.1, "output": 4.98895},
+    return build_success_response(
+        {
+            "id": "unit-converter-cheatsheet",
+            "title": "Unit Converter Cheatsheet",
+            "supported": {
+                "distance": {
+                    "miles_to_kilometers": {
+                        "formula": "mi ÷ 0.621371",
+                        "example": {"input": 3.1, "output": 4.98895},
+                    },
                 },
             },
-        },
-        "notes": [
-            "Negative distances are rejected to keep results meaningful.",
-        ],
-    }
+            "notes": [
+                "Negative distances are rejected to keep results meaningful.",
+            ],
+        }
+    )
 
 
 # How would we scope this?

--- a/app/utils/response_helpers.py
+++ b/app/utils/response_helpers.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_success_response(data: dict[str, Any], message: str = "ok") -> dict[str, Any]:
+    return {"status": message, **data}
+
+
+def build_error_response(
+    message: str,
+    code: str = "error",
+    status_code: int = 400,
+) -> dict[str, Any]:
+    return {"status": code, "error": message, "status_code": status_code}

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from app.mcp.mcp_prompts.converter_prompts import explain_conversion_prompt
 from app.mcp.mcp_resources.converter_resources import RESOURCE_DEFINITIONS
 from app.mcp.mcp_tools.miles_to_km import router as mile_to_km
 from app.utils.resource_utils import register_resources
+from app.utils.response_helpers import build_success_response
 
 # FastAPI app for plain HTTP
 app = FastAPI(
@@ -31,26 +32,28 @@ started_at = time.time()
 
 @system_router.get("/")
 def root():
-    return {
-        "service": "unit-converter-mcp-server",
-        "status": "ok",
-        "docs": "/docs",
-        "health": "/health",
-        "mcp": "/mcp/",
-    }
+    return build_success_response(
+        {
+            "service": "unit-converter-mcp-server",
+            "docs": "/docs",
+            "health": "/health",
+            "mcp": "/mcp/",
+        }
+    )
 
 
 @system_router.get("/health")
 def health():
-    return {
-        "status": "ok",
-        "timestamp": datetime.datetime.now(datetime.UTC).isoformat() + "Z",
-        "python": platform.python_version(),
-        "platform": platform.platform(),
-        "pid": os.getpid(),
-        "cwd": os.getcwd(),
-        "uptime_seconds": round(time.time() - started_at, 2),
-    }
+    return build_success_response(
+        {
+            "timestamp": datetime.datetime.now(datetime.UTC).isoformat() + "Z",
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "pid": os.getpid(),
+            "cwd": os.getcwd(),
+            "uptime_seconds": round(time.time() - started_at, 2),
+        }
+    )
 
 
 app.include_router(system_router)


### PR DESCRIPTION
Closes #63

Adds build_success_response and build_error_response helpers for consistent response formatting at the transport boundary.