### PR TITLE
[Refactor]: add a small factory for MCP test clients

### DIFF
--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -65,6 +65,38 @@ class MCPTestClient:
         return self.client.post(self.url, json=payload, headers=self.headers)
 
 
+def build_mcp_test_client(
+    http_client: httpx.Client,
+    url: str,
+    headers: dict[str, str] | None = None,
+    protocol_version: str = "2025-06-18",
+    client_name: str = "pytest",
+    client_version: str = "1.0",
+) -> MCPTestClient:
+    if headers is None:
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "MCP-Protocol-Version": protocol_version,
+        }
+
+    client = MCPTestClient(http_client, url, headers)
+
+    init_response = client.rpc(
+        "initialize",
+        {
+            "protocolVersion": protocol_version,
+            "capabilities": {},
+            "clientInfo": {"name": client_name, "version": client_version},
+        },
+        rpc_id=0,
+    )
+    assert init_response.status_code in {200, 202}
+
+    client.notification("notifications/initialized")
+    return client
+
+
 def parse_mcp_response(response: httpx.Response) -> dict:
     content_type = response.headers.get("content-type", "")
     if "text/event-stream" not in content_type:
@@ -79,18 +111,9 @@ def parse_mcp_response(response: httpx.Response) -> dict:
 
 @pytest.fixture
 def mcp_client(http_client, mcp_url, mcp_headers, protocol_version):
-    client = MCPTestClient(http_client, mcp_url, mcp_headers)
-
-    init_response = client.rpc(
-        "initialize",
-        {
-            "protocolVersion": protocol_version,
-            "capabilities": {},
-            "clientInfo": {"name": "pytest", "version": "1.0"},
-        },
-        rpc_id=0,
+    return build_mcp_test_client(
+        http_client,
+        mcp_url,
+        headers=mcp_headers,
+        protocol_version=protocol_version,
     )
-    assert init_response.status_code in {200, 202}
-
-    client.notification("notifications/initialized")
-    return client

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -1,30 +1,19 @@
-from tests.mcp.conftest import parse_mcp_response
+from tests.mcp.conftest import build_mcp_test_client
 
 
 def test_initialise_server(mcp_url, mcp_headers, http_client, protocol_version):
-    payload = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "initialize",
-        "params": {
-            "protocolVersion": protocol_version,
-            "capabilities": {},
-            "clientInfo": {"name": "pytest", "version": "1.0"},
-        },
-    }
+    client = build_mcp_test_client(
+        http_client,
+        mcp_url,
+        headers=mcp_headers,
+        protocol_version=protocol_version,
+    )
 
-    response = http_client.post(mcp_url, json=payload, headers=mcp_headers)
+    assert client.session_id is not None
+    assert "Mcp-Session-Id" in client.headers
 
-    assert response.status_code in {200, 202}
-    assert response.headers.get("mcp-session-id")
-    body = parse_mcp_response(response)
-    print(f"[test_initialise_server] status_code={response.status_code}")
-    print(f"[test_initialise_server] headers={dict(response.headers)}")
-    print(f"[test_initialise_server] body={body}")
-    assert body["jsonrpc"] == "2.0"
-    assert body["id"] == 1
-    assert "result" in body
-    assert "serverInfo" in body["result"]
+    print(f"[test_initialise_server] headers={dict(client.headers)}")
+    print(f"[test_initialise_server] session_id={client.session_id}")
 
 
 def test_initialized_notification(mcp_client):


### PR DESCRIPTION
Closes #66

Adds build_mcp_test_client() factory to conftest.py for cleaner test setup with shared defaults.