### PR TITLE
feat: add EventHook interface and NullEventHook for process updates

### DIFF
--- a/app/shared/__init__.py
+++ b/app/shared/__init__.py
@@ -1,0 +1,3 @@
+from .event_hook import EventHook, NullEventHook, ProcessEvent
+
+__all__ = ["EventHook", "NullEventHook", "ProcessEvent"]

--- a/app/shared/event_hook.py
+++ b/app/shared/event_hook.py
@@ -1,0 +1,62 @@
+"""
+Minimal event hook interface for process and task updates.
+
+Provides a small observer-style hook that service logic can call
+when important actions happen, without depending on FastAPI, MCP,
+or LLM code. Not a full event system — just a clean extension point.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass
+class ProcessEvent:
+    """
+    A simple, domain-neutral event describing a process or task update.
+
+    Attributes:
+        name:      Short label for the event e.g. "task.completed"
+        payload:   Optional key/value context about the event.
+        timestamp: UTC time the event was created.
+    """
+    name: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+class EventHook(ABC):
+    """
+    Abstract base for observer-style event hooks.
+
+    Service logic calls ``handle(event)`` when an important action occurs.
+    Concrete implementations can log, notify, audit, or summarise — all
+    without the service knowing the details.
+
+    Deliberately kept framework-free: no FastAPI, MCP, or LLM imports.
+    """
+
+    @abstractmethod
+    def handle(self, event: ProcessEvent) -> None:
+        """
+        React to a process event.
+
+        Args:
+            event: The event describing what happened.
+        """
+
+
+class NullEventHook(EventHook):
+    """
+    No-op default implementation of EventHook.
+
+    Safe to use anywhere a hook is required but nothing needs wiring yet.
+    Replace with a real implementation when the feature is needed.
+    """
+
+    def handle(self, event: ProcessEvent) -> None:
+        pass  # intentional no-op

--- a/tests/test_event_hook.py
+++ b/tests/test_event_hook.py
@@ -1,0 +1,41 @@
+from datetime import timezone
+from app.shared.event_hook import EventHook, NullEventHook, ProcessEvent
+
+
+def test_process_event_defaults():
+    event = ProcessEvent(name="task.completed")
+    assert event.name == "task.completed"
+    assert event.payload == {}
+    assert event.timestamp.tzinfo == timezone.utc
+
+
+def test_process_event_with_payload():
+    event = ProcessEvent(name="task.failed", payload={"reason": "timeout"})
+    assert event.payload["reason"] == "timeout"
+
+
+def test_null_event_hook_handles_without_error():
+    hook = NullEventHook()
+    event = ProcessEvent(name="process.started", payload={"id": 42})
+    hook.handle(event)  # should not raise
+
+
+def test_event_hook_is_abstract():
+    import pytest
+    with pytest.raises(TypeError):
+        EventHook()  # cannot instantiate abstract class
+
+
+def test_custom_hook_receives_event():
+    received = []
+
+    class TestHook(EventHook):
+        def handle(self, event: ProcessEvent) -> None:
+            received.append(event)
+
+    hook = TestHook()
+    event = ProcessEvent(name="order.updated", payload={"order_id": 1})
+    hook.handle(event)
+
+    assert len(received) == 1
+    assert received[0].name == "order.updated"


### PR DESCRIPTION
Closes #64

## What this adds
- ProcessEvent dataclass — name, payload, UTC timestamp
- EventHook abstract base class with handle(event) method  
- NullEventHook no-op default for safe use before real hooks are wired
- Tests covering all acceptance criteria from the issue

## Out of scope (per issue)
- No full event bus
- No notifications or logging framework  
- Not wired into every module — just available for future use