### PR TITLE
fix: MCPTestClient.rpc() now accepts 'id' keyword argument

### DIFF
--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -46,7 +46,8 @@ class MCPTestClient:
         self.headers = dict(headers)
         self.session_id = None
 
-    def rpc(self, method: str, params: dict | None = None, rpc_id: int | str = 1):
+    def rpc(self, method: str, params: dict | None = None, rpc_id: int | str = 1, **kwargs):
+        rpc_id = kwargs.get("id", rpc_id)
         payload: dict[str, Any] = {"jsonrpc": "2.0", "id": rpc_id, "method": method}
         if params is not None:
             payload["params"] = params


### PR DESCRIPTION
Fixes #84

## Problem
`MCPTestClient.rpc()` has `rpc_id` parameter, but test files call it with `id=...` keyword argument, causing `TypeError`.

## Fix
Added `**kwargs` to `rpc()` method signature and fallback to `kwargs.get("id", rpc_id)`, so both `rpc_id=2` and `id=2` work.