### PR TITLE
fix: align request-model and runtime validation for miles-to-km input

### DIFF
--- a/app/mcp/mcp_tools/miles_to_km.py
+++ b/app/mcp/mcp_tools/miles_to_km.py
@@ -12,10 +12,10 @@ MAX_TUTORIAL_MILES = 100_000
 # --- Request/Response models for clarity ---
 class MilestoKmRequest(BaseModel):
     """Request model for miles to kilometers conversion, with validation.
-    Attributes: ge=0 ensures non-negative input, and description provides API documentation.
+    Attributes: ge=1 ensures non-negative input, and description provides API documentation.
     """
 
-    miles: float = Field(..., ge=0, description="Distance in miles (>= 0)")
+    miles: float = Field(..., ge=1, description="Distance in miles (>= 0)")
 
 
 class MilestoKmResponse(BaseModel):


### PR DESCRIPTION
Fixes #47

## Problem
Request model uses `ge=0` (allows 0 miles) but conversion function rejects 0 with "must be greater than zero". This creates ambiguous API contract.

## Fix
Changed `ge=0` to `ge=1` in the request model so both layers consistently reject 0 miles.