### PR TITLE
Fix/correct fastapi depends usage for session

### DIFF
--- a/app/routes/route_tasks.py
+++ b/app/routes/route_tasks.py
@@ -10,8 +10,8 @@ task_router = Router.task_router
 
 
 @task_router.get("/get-name", response_model=PLTask)
-def get_task_by_name(session: Session, name: str | None = None) -> PLTask:
-    session = Depends(get_session_api)
+def get_task_by_name(session: Session = Depends(get_session_api),
+                     name: str | None = None) -> PLTask:
     try:
         task = TaskHandler.get_task(session, name)
     except Exception as e:

--- a/app/routes/route_tasks.py
+++ b/app/routes/route_tasks.py
@@ -50,8 +50,8 @@ def delete_task_by_name(session: Session = Depends(get_session_api),
 
 
 @task_router.post("/add")
-def create_task(session: Session, task: PLTask = None) -> PLTask:
-    session = Depends(get_session_api)
+def create_task(session: Session = Depends(get_session_api),
+                task: PLTask = None) -> PLTask:
     try:
         task = TaskHandler.add_task_to_db(session, task)
     except Exception as e:

--- a/app/routes/route_tasks.py
+++ b/app/routes/route_tasks.py
@@ -27,8 +27,8 @@ def get_task_by_name(session: Session = Depends(get_session_api),
 
 
 @task_router.get("/get-id", response_model=PLTask)
-def get_task_by_id(session: Session, task_id: int | None = None) -> PLTask:
-    session = Depends(get_session_api)
+def get_task_by_id(session: Session = Depends(get_session_api),
+                   task_id: int | None = None) -> PLTask:
     try:
         task = TaskHandler.get_task(session, task_id)
     except Exception as e:

--- a/app/routes/route_tasks.py
+++ b/app/routes/route_tasks.py
@@ -66,7 +66,7 @@ def filter_task_by_type(session: Session = Depends(get_session_api),
 
 
 @task_router.post("/complete")
-def complete_task(session: Session, name: str | None = None) -> PLTask:
-    session = Depends(get_session_api)
+def complete_task(session: Session = Depends(get_session_api),
+                  name: str | None = None) -> PLTask:
     task = TaskHandler.get_task(session, name)
     return TaskHandler.complete_task(session, task)

--- a/app/routes/route_tasks.py
+++ b/app/routes/route_tasks.py
@@ -10,8 +10,8 @@ task_router = Router.task_router
 
 
 @task_router.get("/get-name", response_model=PLTask)
-def get_task_by_name(session: Session = Depends(get_session_api),
-                     name: str | None = None) -> PLTask:
+def get_task_by_name(name: str | None = None) -> PLTask:
+    session: Session = Depends(get_session_api)
     try:
         task = TaskHandler.get_task(session, name)
     except Exception as e:
@@ -27,8 +27,8 @@ def get_task_by_name(session: Session = Depends(get_session_api),
 
 
 @task_router.get("/get-id", response_model=PLTask)
-def get_task_by_id(session: Session = Depends(get_session_api),
-                   task_id: int | None = None) -> PLTask:
+def get_task_by_id(task_id: int | None = None) -> PLTask:
+    session: Session = Depends(get_session_api)
     try:
         task = TaskHandler.get_task(session, task_id)
     except Exception as e:
@@ -44,14 +44,14 @@ def get_task_by_id(session: Session = Depends(get_session_api),
 
 
 @task_router.post("/delete")
-def delete_task_by_name(session: Session = Depends(get_session_api),
-                        name: str | None = None):
+def delete_task_by_name(name: str | None = None):
+    session: Session = Depends(get_session_api)
     TaskHandler.delete_task(session, name)
 
 
 @task_router.post("/add")
-def create_task(session: Session = Depends(get_session_api),
-                task: PLTask = None) -> PLTask:
+def create_task(task: PLTask = None) -> PLTask:
+    session: Session = Depends(get_session_api)
     try:
         task = TaskHandler.add_task_to_db(session, task)
     except Exception as e:
@@ -60,13 +60,13 @@ def create_task(session: Session = Depends(get_session_api),
 
 
 @task_router.get("/task-list")
-def filter_task_by_type(session: Session = Depends(get_session_api),
-                        task_type: str | None = None) -> list[PLTask]:
+def filter_task_by_type(task_type: str | None = None) -> list[PLTask]:
+    session: Session = Depends(get_session_api)
     return TaskHandler.list_tasks(session, task_type)
 
 
 @task_router.post("/complete")
-def complete_task(session: Session = Depends(get_session_api),
-                  name: str | None = None) -> PLTask:
+def complete_task(name: str | None = None) -> PLTask:
+    session: Session = Depends(get_session_api)
     task = TaskHandler.get_task(session, name)
     return TaskHandler.complete_task(session, task)

--- a/app/routes/route_tasks.py
+++ b/app/routes/route_tasks.py
@@ -44,8 +44,8 @@ def get_task_by_id(session: Session = Depends(get_session_api),
 
 
 @task_router.post("/delete")
-def delete_task_by_name(session: Session, name: str | None = None):
-    session = Depends(get_session_api)
+def delete_task_by_name(session: Session = Depends(get_session_api),
+                        name: str | None = None):
     TaskHandler.delete_task(session, name)
 
 

--- a/app/routes/route_tasks.py
+++ b/app/routes/route_tasks.py
@@ -60,8 +60,8 @@ def create_task(session: Session = Depends(get_session_api),
 
 
 @task_router.get("/task-list")
-def filter_task_by_type(session: Session, task_type: str | None = None) -> list[PLTask]:
-    session = Depends(get_session_api)
+def filter_task_by_type(session: Session = Depends(get_session_api),
+                        task_type: str | None = None) -> list[PLTask]:
     return TaskHandler.list_tasks(session, task_type)
 
 


### PR DESCRIPTION
## Description

This PR fixes incorrect FastAPI dependency injection usage for SQLAlchemy Session across multiple router endpoints.

Previously, Depends(get_session_api) was incorrectly assigned inside function bodies instead of being declared as a function parameter. This caused FastAPI to interpret Session as a request/response field type, leading to a FastAPIError.
How it looks like this:

<img width="611" height="324" alt="image" src="https://github.com/user-attachments/assets/876c8f32-6e7f-4ceb-afef-9a7819c3335a" />


All affected endpoints have been updated to properly use Depends(get_session_api) in function signatures.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Manually tested by running the FastAPI application locally and verified that the server starts up

<img width="996" height="298" alt="image" src="https://github.com/user-attachments/assets/7586250a-61b4-43a1-a9ea-63b47b5771bb" />

No startup errors occur after applying the fix.

## Checklist:

- [x] I have followed the coding style guidelines of this project
- [x] I have reviewed my own code
- [x] I have commented hard-to-understand areas of my code
- [x] I have added docstrings to all public functions/methods
- [x] I have used descriptive variable names to make by code easier to understand
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issue(s)

Closes #88 
