### PR TITLE
docs: add MCP tool naming guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Add or update example LLM client code here:
 example_llm_client/
 ```
 
+### Adding New MCP Tools
+
+For details on MCP tools, see [mcp-tools-naming-guide.md](org/mcp-tools-naming-guide.md).
+
 ## Contributing
 
 For detailed contribution guidelines, see [CONTRIBUTION.md](CONTRIBUTION.md).

--- a/app/mcp/mcp_tools/miles_to_km.py
+++ b/app/mcp/mcp_tools/miles_to_km.py
@@ -62,8 +62,7 @@ def miles_to_kilometers_value(miles: float | None) -> float:
     return miles_to_kilometers_converter(miles)
 
 
-@router.post("/convert-miles-to-kilometers",
-             operation_id="convert_miles_to_kilometers")
+@router.post("/convert-miles-to-kilometers", operation_id="convert_miles_to_kilometers")
 # def miles_to_kilometers(miles: float):
 def miles_to_kilometers(
     body: MilestoKmRequest,

--- a/app/mcp/mcp_tools/miles_to_km.py
+++ b/app/mcp/mcp_tools/miles_to_km.py
@@ -62,7 +62,8 @@ def miles_to_kilometers_value(miles: float | None) -> float:
     return miles_to_kilometers_converter(miles)
 
 
-@router.post("/convert-miles-to-kilometers")
+@router.post("/convert-miles-to-kilometers",
+             operation_id="convert_miles_to_kilometers")
 # def miles_to_kilometers(miles: float):
 def miles_to_kilometers(
     body: MilestoKmRequest,

--- a/app/mcp/mcp_tools/miles_to_km.py
+++ b/app/mcp/mcp_tools/miles_to_km.py
@@ -62,7 +62,7 @@ def miles_to_kilometers_value(miles: float | None) -> float:
     return miles_to_kilometers_converter(miles)
 
 
-@router.post("/miles-to-kilometers")
+@router.post("/convert-miles-to-kilometers")
 # def miles_to_kilometers(miles: float):
 def miles_to_kilometers(
     body: MilestoKmRequest,

--- a/app/mcp/mcp_tools/miles_to_km.py
+++ b/app/mcp/mcp_tools/miles_to_km.py
@@ -81,7 +81,7 @@ def miles_to_kilometers(
         result = miles_to_kilometers_value(body.miles)
         return MilestoKmResponse(
             result=result,
-            operation="miles_to_kilometers",
+            operation="convert_miles_to_kilometers",
             audited_at=time.time(),
         )
     except ValidationError as exc:
@@ -92,7 +92,7 @@ def miles_to_kilometers(
 
 TOOL_DEFINITION = [
     {
-        "name": "miles_to_kilometers",
+        "name": "convert_miles_to_kilometers",
         "description": "Convert miles to kilometers (validates non-negative input)",
         "func": miles_to_kilometers_value,
         "tags": {"distance", "conversion"},

--- a/org/mcp-tools-naming-guide.md
+++ b/org/mcp-tools-naming-guide.md
@@ -8,4 +8,50 @@ human-readable, and consistent across implementation, tests and documentation.
 
 ## Naming convention:
 
-WIP
+All MCP tool names MUST follow this structure:
+> `<action>_<target>`
+
+### 1. Action (what the tool does)
+The action describes the operation being performed.
+
+Common actions include:
+- convert → unit or format conversion
+- calculate → mathematical computation
+- create → create a resource
+- delete → remove a resource
+- get → retrieve a resource
+- update → modify a resource
+
+Additional actions may be added only when necessary,
+but reuse of existing actions is preferred.
+
+### 2. Target (what the tool operates on)
+The target describes the domain or object being acted upon.
+Examples:
+- miles_to_km
+- task
+
+Targets should be:
+- lowercase or snake_case
+- descriptive
+- consistent across related tools
+
+### Additional context
+Examples of tool names
+
+| Intended Behaviour          | MCP Tool Name         |
+| --------------------------- | --------------------- |
+| Convert miles to kilometers | `convert_miles_to_km` |
+| Convert km to miles         | `convert_km_to_miles` |
+| Calculate distance          | `calculate_distance`  |
+| Get task by id              | `get_task_by_id`      |
+| Delete task by name         | `delete_task_by_name` |
+| Filter tasks by type        | `filter_task_by_type` |
+
+### Design Rules
+- Tool names MUST NOT be auto-generated route names
+- Tool names MUST be stable and human-readable
+- Tool names MUST match:
+  - implementation
+  - tests
+  - documentation (README / guides)

--- a/org/mcp-tools-naming-guide.md
+++ b/org/mcp-tools-naming-guide.md
@@ -41,7 +41,7 @@ Examples of tool names
 
 | Intended Behaviour          | MCP Tool Name         |
 | --------------------------- | --------------------- |
-| Convert miles to kilometers | `convert_miles_to_km` |
+| Convert miles to kilometers | `convert_miles_to_kilometers` |
 | Convert km to miles         | `convert_km_to_miles` |
 | Calculate distance          | `calculate_distance`  |
 | Get task by id              | `get_task_by_id`      |

--- a/org/mcp-tools-naming-guide.md
+++ b/org/mcp-tools-naming-guide.md
@@ -1,0 +1,11 @@
+# MCP Tools Naming Guide
+
+## Purpose 
+
+This document defines the naming convention used for MCP tools
+with the project. The goal is to ensure that tool names are predicatable,
+human-readable, and consistent across implementation, tests and documentation.
+
+## Naming convention:
+
+WIP

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -24,8 +24,8 @@ def test_tools_call_miles_to_km(mcp_client):
     response = mcp_client.rpc(
         "tools/call",
         {
-            "name": "miles_to_km_miles_to_km_post",
-            "arguments": {"fahrenheit": 77},
+            "name": "convert_miles_to_kilometers",
+            "arguments": {"miles": 77},
         },
         id=3,
     )


### PR DESCRIPTION
## Description

This PR introduces and refines an MCP Tool Naming Guide to define a consistent and stable naming convention for MCP tools within the project.

The naming convention ensures that all MCP tools follow a predictable, human-readable format and remain consistent across implementation, tests, and documentation.

Changes made:
- Added the MCP Tool Naming guide
- Standardized tool naming across the MCP router using `operation_id` to prevent auto-generated route-based names.
- Updated MCP tool definition to ensure consistent naming across registry, implementation, and tests.
- Fixed unit tests to match the updated tool name
- Ensured documentation, implementation, and tests all reference the same stable tool identifier.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Automated testing:
- Ran unit tests using:
```
python -m pytest -v
```
<img width="555" height="179" alt="image" src="https://github.com/user-attachments/assets/cecc1919-07e2-4d0d-8861-b9d54409d4b2" />

Manual testing:

- Ran the MCP unit test `test_tools.py`:
<img width="1044" height="190" alt="image" src="https://github.com/user-attachments/assets/f85a0e2a-46cf-4f48-8ff1-9dce6a92ea3d" />

## Checklist:

- [x] I have followed the coding style guidelines of this project
- [x] I have reviewed my own code
- [x] I have commented hard-to-understand areas of my code
- [x] I have added docstrings to all public functions/methods
- [x] I have used descriptive variable names to make by code easier to understand
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issue(s)

closes #44 
