### PR TITLE
docs: add reusable curl workflow commands

### DIFF
--- a/app/docs/curl_testing/mcp_curl_test_examples.md
+++ b/app/docs/curl_testing/mcp_curl_test_examples.md
@@ -24,6 +24,39 @@ PROTO="MCP-Protocol-Version: 2025-06-18"
 
 ```
 
+## Reusable developer workflow commands
+
+These commands provide a quick smoke-test workflow for developers who want to verify the server, MCP endpoint, and direct HTTP routes from the terminal.
+
+```bash
+# Base URLs
+BASE=${BASE:-http://localhost:8003}
+MCP=${MCP:-$BASE/mcp/}
+
+# Shared MCP headers
+ACCEPT="Accept: application/json, text/event-stream"
+PROTO="MCP-Protocol-Version: 2025-06-18"
+
+# 1. Check server health
+curl -s "$BASE/health"
+
+# 2. Start an MCP session and capture the session id
+SESSION=$(curl -sD - -o /dev/null "$MCP" \
+  -H "Content-Type: application/json" \
+  -H "$ACCEPT" \
+  -H "$PROTO" \
+  -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}' \
+  | awk 'BEGIN{IGNORECASE=1} /^mcp-session-id:/ {sub(/\r$/,""); print $2}')
+
+# 3. List available MCP tools
+curl -s "$MCP" \
+  -H "Content-Type: application/json" \
+  -H "$ACCEPT" \
+  -H "$PROTO" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
 ## Quick connectivity + session capture (run this first)
 
 ```bash


### PR DESCRIPTION
## Description

Added a reusable curl smoke-test workflow to `app/docs/curl_testing/mcp_curl_test_examples.md`.

The new section helps developers quickly verify:

* the server health endpoint
* MCP session initialization
* MCP `tools/list` request flow

## Type of change

Please delete options that are not relevant.

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## How Has This Been Tested?

Documentation-only change.

I verified the Markdown diff locally and confirmed the change only adds the reusable curl workflow section.

## Checklist:

* [x] I have followed the coding style guidelines of this project
* [x] I have reviewed my own code
* [ ] I have commented hard-to-understand areas of my code
* [ ] I have added docstrings to all public functions/methods
* [x] I have used descriptive variable names to make my code easier to understand
* [x] I have made corresponding changes to the documentation
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes

## Related Issue(s)

Closes #113
