### PR TITLE
Fix TestClient deprecation warning in rate limit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "httpx2>=2.4.0",
   "hypothesis>=6.152.7",
   "pytest>=9.0.3",
   "pytest-asyncio>=1.3.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -71,11 +71,15 @@ h11==0.16.0
     #   uvicorn
 httpcore==1.0.9
     # via httpx
+httpcore2==2.4.0
+    # via httpx2
 httpx==0.28.1
     # via
     #   ipos-open-source-2026s1 (pyproject.toml)
     #   fastmcp-slim
     #   mcp
+httpx2==2.4.0
+    # via ipos-open-source-2026s1 (pyproject.toml:dev)
 httpx-sse==0.4.3
     # via mcp
 hypothesis==6.152.7
@@ -213,6 +217,8 @@ starlette==1.0.0
     #   fastapi
     #   mcp
     #   sse-starlette
+truststore==0.10.4
+    # via httpx2
 ty==0.0.37
     # via ipos-open-source-2026s1 (pyproject.toml:dev)
 typing-extensions==4.15.0


### PR DESCRIPTION
Fixes #110.

Starlette 1.x prefers httpx2 for TestClient and emits a StarletteDeprecationWarning when it falls back to httpx. The rate limit tests import FastAPI's TestClient, so the suite still passed but always produced the warning during import.

This keeps the existing httpx dependency for app/client code and adds httpx2 to the dev/test dependency set. requirements-dev.txt is updated with httpx2 plus its httpcore2 and truststore dependencies.

Checked locally:
- python -m pytest tests/mcp/test_rate_limit.py -W error::starlette.exceptions.StarletteDeprecationWarning --basetemp .pytest_tmp
- git diff --check

Also tried python -m pytest tests/mcp --basetemp .pytest_tmp. The rate limit tests passed, but the broader MCP suite expects a local server at localhost:8003 and failed with httpx.ConnectError because that service was not running in this environment.