### PR TITLE
Align miles-to-kilometers request validation

### DIFF
--- a/app/mcp/mcp_tools/miles_to_km.py
+++ b/app/mcp/mcp_tools/miles_to_km.py
@@ -10,15 +10,23 @@ from app.mcp.mcp_tools.conversion import miles_to_kilometers_converter
 router = APIRouter(prefix="", tags=["unit-conversion"])
 
 MAX_TUTORIAL_MILES = 100_000
+MIN_TUTORIAL_MILES = 0.0001
 
 
 # --- Request/Response models for clarity ---
 class MilestoKmRequest(BaseModel):
     """Request model for miles to kilometers conversion, with validation.
-    Attributes: ge=0 ensures non-negative input, and description provides API documentation.
+
+    Attributes: miles must be within the same supported range as the runtime
+    converter.
     """
 
-    miles: float = Field(..., ge=0, description="Distance in miles (>= 0)")
+    miles: float = Field(
+        ...,
+        ge=MIN_TUTORIAL_MILES,
+        le=MAX_TUTORIAL_MILES,
+        description="Distance in miles (0.0001 to 100000)",
+    )
 
 
 class MilestoKmResponse(BaseModel):
@@ -33,7 +41,7 @@ class MilestoKmResponse(BaseModel):
 
 def miles_to_kilometers_value(miles: float | None) -> float:
     """
-    Convert miles to kilometers, rejecting negative inputs.
+    Convert miles to kilometers, rejecting unsupported inputs.
 
     Args:
         miles: Distance in miles.
@@ -42,7 +50,7 @@ def miles_to_kilometers_value(miles: float | None) -> float:
         The distance in kilometers.
 
     Raises:
-        ValueError: If a negative distance is provided.
+        ValidationError: If distance is missing, non-finite, or out of range.
     """
     if miles is None:
         raise ValidationError("Miles is required.")
@@ -52,7 +60,7 @@ def miles_to_kilometers_value(miles: float | None) -> float:
         raise ValidationError("Miles must be a finite number.")
     if miles <= 0:
         raise ValidationError("Distance must be greater than zero.")
-    if miles < 0.0001:  # noqa: PLR2004
+    if miles < MIN_TUTORIAL_MILES:
         raise ValidationError("Distance is too small to be meaningful.")
     if miles > MAX_TUTORIAL_MILES:
         raise ValidationError(
@@ -92,7 +100,7 @@ def miles_to_kilometers(
 TOOL_DEFINITION = [
     {
         "name": "miles_to_kilometers",
-        "description": "Convert miles to kilometers (validates non-negative input)",
+        "description": "Convert miles to kilometers (validates supported range)",
         "func": miles_to_kilometers_value,
         "tags": {"distance", "conversion"},
     },

--- a/tests/mcp/test_validation_exception.py
+++ b/tests/mcp/test_validation_exception.py
@@ -1,7 +1,13 @@
 import pytest
+from pydantic import ValidationError as PydanticValidationError
 
 from app.core.exceptions import ValidationError
-from app.mcp.mcp_tools.miles_to_km import miles_to_kilometers_value
+from app.mcp.mcp_tools.miles_to_km import (
+    MAX_TUTORIAL_MILES,
+    MIN_TUTORIAL_MILES,
+    MilestoKmRequest,
+    miles_to_kilometers_value,
+)
 
 EXPECTED_KM = 1.609
 CONVERSION_TOLERANCE = 0.001
@@ -24,6 +30,28 @@ def test_negative_miles_raises_validation_error():
 def test_zero_miles_raises_validation_error():
     with pytest.raises(ValidationError):
         miles_to_kilometers_value(0)
+
+
+def test_request_model_rejects_zero_miles():
+    with pytest.raises(PydanticValidationError):
+        MilestoKmRequest(miles=0)
+
+
+def test_request_model_rejects_too_small_miles():
+    with pytest.raises(PydanticValidationError):
+        MilestoKmRequest(miles=MIN_TUTORIAL_MILES / 10)
+
+
+def test_request_model_rejects_too_large_miles():
+    with pytest.raises(PydanticValidationError):
+        MilestoKmRequest(miles=MAX_TUTORIAL_MILES + 1)
+
+
+def test_request_model_accepts_runtime_boundary_miles():
+    assert MilestoKmRequest(miles=MIN_TUTORIAL_MILES).miles == pytest.approx(
+        MIN_TUTORIAL_MILES
+    )
+    assert MilestoKmRequest(miles=MAX_TUTORIAL_MILES).miles == MAX_TUTORIAL_MILES
 
 
 def test_none_miles_raises_validation_error():


### PR DESCRIPTION
## Summary
- Align `MilestoKmRequest` with the runtime converter validation range.
- Keep zero rejected and share explicit min/max constants between model and runtime checks.
- Add request-model boundary tests for zero, too-small, too-large, and accepted boundary values.

Fixes #47.

## Tests
- `uv run --group dev pytest tests/mcp/test_validation_exception.py -q`
- `uv run --group dev ruff check app/mcp/mcp_tools/miles_to_km.py tests/mcp/test_validation_exception.py`
- `uv run --group dev ruff format --check app/mcp/mcp_tools/miles_to_km.py tests/mcp/test_validation_exception.py`
- `uv run --group dev python -m compileall app/mcp/mcp_tools/miles_to_km.py tests/mcp/test_validation_exception.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`